### PR TITLE
Expose target UUID

### DIFF
--- a/periskop_client/collector.py
+++ b/periskop_client/collector.py
@@ -39,7 +39,10 @@ class ExceptionCollector:
 
         :return Payload: list of aggregated exceptions
         """
-        return Payload(aggregated_errors=list(self._aggregated_exceptions.values()), target_uuid=self._uuid)
+        return Payload(
+            aggregated_errors=list(self._aggregated_exceptions.values()),
+            target_uuid=self._uuid,
+        )
 
     def _add_exception(self, exception: Exception, http_context: HTTPContext = None):
         stacktrace = traceback.format_exc().strip().split("\n")

--- a/periskop_client/collector.py
+++ b/periskop_client/collector.py
@@ -1,4 +1,5 @@
 import traceback
+import uuid
 from typing import Dict
 
 from .models import (
@@ -13,6 +14,7 @@ from .models import (
 class ExceptionCollector:
     def __init__(self):
         self._aggregated_exceptions: Dict[str, AggregatedException] = {}
+        self._uuid = str(uuid.uuid1())
 
     def report(self, exception: Exception):
         """
@@ -37,7 +39,7 @@ class ExceptionCollector:
 
         :return Payload: list of aggregated exceptions
         """
-        return Payload(aggregated_errors=list(self._aggregated_exceptions.values()))
+        return Payload(aggregated_errors=list(self._aggregated_exceptions.values()), target_uuid=self._uuid)
 
     def _add_exception(self, exception: Exception, http_context: HTTPContext = None):
         stacktrace = traceback.format_exc().strip().split("\n")

--- a/periskop_client/models.py
+++ b/periskop_client/models.py
@@ -91,3 +91,5 @@ class AggregatedException:
 @dataclass
 class Payload:
     aggregated_errors: List[AggregatedException]
+    target_uuid: str
+

--- a/periskop_client/models.py
+++ b/periskop_client/models.py
@@ -92,4 +92,3 @@ class AggregatedException:
 class Payload:
     aggregated_errors: List[AggregatedException]
     target_uuid: str
-

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 def test_export(collector, exporter, sample_http_context):
     expected = """
 {
+	"target_uuid": "5d9893c6-51d6-11ea-8aad-f894c260afe5",
   "aggregated_errors": [
     {
       "aggregation_key": "Exception@a9a59d26",
@@ -39,5 +40,6 @@ def test_export(collector, exporter, sample_http_context):
 }"""
     with mock.patch("uuid.uuid1", return_value="5d9893c6-51d6-11ea-8aad-f894c260afe5"):
         collector.report_with_context(exception=Exception("test"), http_context=sample_http_context)
+        collector._uuid = "5d9893c6-51d6-11ea-8aad-f894c260afe5"
         exported = exporter.export()
         assert json.loads(exported) == json.loads(expected)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 def test_export(collector, exporter, sample_http_context):
     expected = """
 {
-	"target_uuid": "5d9893c6-51d6-11ea-8aad-f894c260afe5",
+  "target_uuid": "5d9893c6-51d6-11ea-8aad-f894c260afe5",
   "aggregated_errors": [
     {
       "aggregation_key": "Exception@a9a59d26",


### PR DESCRIPTION
  - Exposing a UUID per target collector is necessary to avoid
    collisions which may result in wrong counters.
  - See https://github.com/soundcloud/periskop/issues/169
